### PR TITLE
Ignore custom systemd service with APT

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ The location where Supervisor logs will be stored.
 
 The user under which `supervisord` will be run, and the password to be used when connecting to Supervisor's HTTP server (either for `supervisorctl` access, or when viewing the administrative UI).
 
+    supervisor_service_name: supervisord
+
+This role installs a supervisord.service systemd service when appliable. If using apt (i.e. setting `supervisor_apt_install`), the name of the service is changed to `supervisor` by the role.
+
     supervisor_unix_http_server_password_protect: true
     supervisor_inet_http_server_password_protect: true
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,8 @@ supervisor_log_dir: /var/log/supervisor
 supervisor_user: root
 supervisor_password: 'my_secret_password'
 
+supervisor_service_name: supervisord
+
 supervisor_unix_http_server_enable: true
 supervisor_unix_http_server_socket_path: /var/run/supervisor.sock
 supervisor_unix_http_server_socket_owner: root

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,6 @@
 ---
 - name: restart supervisor
-  service: name=supervisord state=restarted
+  service:
+    name: "{{ supervisor_service_name }}"
+    state: restarted
   when: supervisor_started

--- a/tasks/init-setup.yml
+++ b/tasks/init-setup.yml
@@ -16,12 +16,7 @@
     owner: root
     group: root
     mode: 0644
-  when: "ansible_service_mgr == 'systemd'"
+  when:
+    - "ansible_service_mgr == 'systemd'"
+    - not supervisor_apt_install
   notify: restart supervisor
-
-- name: Disable default supervisor systemd service when installing with APT.
-  systemd:
-    name: supervisor
-    state: stopped
-    enabled: false
-  when: supervisor_apt_install

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,11 @@
     state: directory
     mode: 0755
 
+- name: Set supervisor service name for APT
+  set_fact:
+    supervisor_service_name: supervisor
+  when: supervisor_apt_install
+
 - include_tasks: config.yml
 
 - include_tasks: init-setup.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,12 +31,12 @@
 
 - name: Ensure Supervisor is started (if configured).
   service:
-    name: supervisord
+    name: "{{ supervisor_service_name }}"
     state: started
   when: supervisor_started
 
 - name: Ensure Supervisor is enabled at boot (if configured).
   service:
-    name: supervisord
+    name: "{{ supervisor_service_name }}"
     enabled: true
   when: supervisor_enabled


### PR DESCRIPTION
Instead of disabling and stopping the default APT systemd service, we rely on it to handle supervisor instead of the custom systemd service file supplied by the role, when using APT instead of pip for the install.